### PR TITLE
Add type inference to avoid casting

### DIFF
--- a/ballerina/proto3_serdes.bal
+++ b/ballerina/proto3_serdes.bal
@@ -41,9 +41,11 @@ public class Proto3SerDes {
     #
     # + encodedMessage - The encoded byte array of the value that is serialized
     # + return - The value represented by the encoded byte array
-    public isolated function deserialize(byte[] encodedMessage) returns anydata|Error {
-        return deserialize(self, encodedMessage, self.dataType);
-    }
+    public isolated function deserialize(byte[] encodedMessage, typedesc<anydata> T = <>) returns T|Error =
+    @java:Method {
+    'class: "io.ballerina.stdlib.serdes.Deserializer"
+    }  external;
+
 }
 
 public isolated function generateSchema(SerDes serdes, typedesc<anydata> T) returns Error? =
@@ -53,9 +55,4 @@ public isolated function generateSchema(SerDes serdes, typedesc<anydata> T) retu
 
 public isolated function serialize(SerDes ser, anydata data, typedesc<anydata> T) returns byte[]|Error = @java:Method {
     'class: "io.ballerina.stdlib.serdes.Serializer"
-}  external;
-
-public isolated function deserialize(SerDes des, byte[] encodedMessage, typedesc<anydata> T) returns anydata|Error =
-@java:Method {
-    'class: "io.ballerina.stdlib.serdes.Deserializer"
 }  external;

--- a/ballerina/proto3_serdes.bal
+++ b/ballerina/proto3_serdes.bal
@@ -40,6 +40,7 @@ public class Proto3Schema {
     # Deserializes a given array of bytes.
     #
     # + encodedMessage - The encoded byte array of the value that is serialized
+    # + T - the typedesc
     # + return - The value represented by the encoded byte array
     public isolated function deserialize(byte[] encodedMessage, typedesc<anydata> T = <>) returns T|Error =
     @java:Method {

--- a/ballerina/proto3_serdes.bal
+++ b/ballerina/proto3_serdes.bal
@@ -42,7 +42,7 @@ public class Proto3Schema {
     # Deserializes a given array of bytes.
     #
     # + encodedMessage - The encoded byte array of the value that is serialized
-    # + T - the typedesc
+    # + T - The type of the deserialized data. This will be inferred from the expected type
     # + return - The value represented by the encoded byte array
     public isolated function deserialize(byte[] encodedMessage, typedesc<anydata> T = <>) returns T|Error =
     @java:Method {

--- a/ballerina/proto3_serdes.bal
+++ b/ballerina/proto3_serdes.bal
@@ -33,9 +33,11 @@ public class Proto3Schema {
     #
     # + data - The value that is being serialized
     # + return - A byte array corresponding to the encoded value
-    public isolated function serialize(anydata data) returns byte[]|Error {
-        return serialize(self, data, self.dataType);
-    }
+    public isolated function serialize(anydata data) returns byte[]|Error = 
+    @java:Method {
+        'class: "io.ballerina.stdlib.serdes.Serializer"
+    }  external;
+
 
     # Deserializes a given array of bytes.
     #
@@ -52,8 +54,4 @@ public class Proto3Schema {
 public isolated function generateSchema(Schema serdes, typedesc<anydata> T) returns Error? =
 @java:Method {
     'class: "io.ballerina.stdlib.serdes.SchemaGenerator"
-}  external;
-
-public isolated function serialize(Schema ser, anydata data, typedesc<anydata> T) returns byte[]|Error = @java:Method {
-    'class: "io.ballerina.stdlib.serdes.Serializer"
 }  external;

--- a/ballerina/proto3_serdes.bal
+++ b/ballerina/proto3_serdes.bal
@@ -16,8 +16,8 @@
 
 import ballerina/jballerina.java;
 
-public class Proto3SerDes {
-    *SerDes;
+public class Proto3Schema {
+    *Schema;
     private typedesc<anydata> dataType;
 
     # Generates a schema for a given data type.
@@ -48,11 +48,11 @@ public class Proto3SerDes {
 
 }
 
-public isolated function generateSchema(SerDes serdes, typedesc<anydata> T) returns Error? =
+public isolated function generateSchema(Schema serdes, typedesc<anydata> T) returns Error? =
 @java:Method {
     'class: "io.ballerina.stdlib.serdes.SchemaGenerator"
 }  external;
 
-public isolated function serialize(SerDes ser, anydata data, typedesc<anydata> T) returns byte[]|Error = @java:Method {
+public isolated function serialize(Schema ser, anydata data, typedesc<anydata> T) returns byte[]|Error = @java:Method {
     'class: "io.ballerina.stdlib.serdes.Serializer"
 }  external;

--- a/ballerina/serdes.bal
+++ b/ballerina/serdes.bal
@@ -14,8 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# A SerDes object that can be used to create custom serializers/deserializers.
-public type SerDes object {
+# A Schema object that can be used to create custom serializers/deserializers.
+public type Schema object {
 
     public isolated function serialize(anydata data) returns byte[]|Error;
     public isolated function deserialize(byte[] encodedMessage, typedesc<anydata> T = <>) returns T|Error;

--- a/ballerina/serdes.bal
+++ b/ballerina/serdes.bal
@@ -18,5 +18,5 @@
 public type SerDes object {
 
     public isolated function serialize(anydata data) returns byte[]|Error;
-    public isolated function deserialize(byte[] encodedMessage) returns anydata|Error;
+    public isolated function deserialize(byte[] encodedMessage, typedesc<anydata> T = <>) returns T|Error;
 };

--- a/ballerina/tests/errors_test.bal
+++ b/ballerina/tests/errors_test.bal
@@ -22,7 +22,7 @@ type EmployeeTable table<map<any>>;
 public isolated function testUnsupportedDataType() returns error? {
     string expected = "Unsupported data type: table";
 
-    Proto3SerDes|error ser = new(EmployeeTable);
+    Proto3Schema|error ser = new(EmployeeTable);
     test:assertTrue(ser is Error);
     Error err = <Error> ser;
     test:assertEquals(err.message(), expected);
@@ -32,7 +32,7 @@ public isolated function testUnsupportedDataType() returns error? {
 public isolated function testTypeMismatch() returns error? {
     string expected = "Failed to Serialize data: Type mismatch";
 
-    Proto3SerDes ser = check new(float);
+    Proto3Schema ser = check new(float);
     byte[]|error encoded = ser.serialize(123);
     test:assertTrue(encoded is Error);
     Error err = <Error> encoded;
@@ -55,7 +55,7 @@ public isolated function testRecordTypeMismatch() returns error? {
     string expected = "Failed to Serialize data: Type mismatch";
 
     Engineer SE = {name: "Jane Doe", id: 123};
-    Proto3SerDes ser = check new(Chairman);
+    Proto3Schema ser = check new(Chairman);
     byte[]|error encoded = ser.serialize(SE);
     test:assertTrue(encoded is Error);
     Error err = <Error> encoded;

--- a/ballerina/tests/unit_tests.bal
+++ b/ballerina/tests/unit_tests.bal
@@ -77,7 +77,7 @@ public isolated function testPrimitiveFloat() returns error? {
     byte[] encoded = check ser.serialize(6.666);
 
     Proto3SerDes des = check new(float);
-    float decoded = <float>check des.deserialize(encoded);
+    float decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, 6.666);
 }
 
@@ -87,7 +87,7 @@ public isolated function testPrimitiveDecimal() returns error? {
     byte[] encoded = check ser.serialize(1.23);
 
     Proto3SerDes des = check new(decimal);
-    float decoded = <float>check des.deserialize(encoded);
+    float decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, 1.23);
 }
 
@@ -97,7 +97,7 @@ public isolated function testPrimitiveBoolean() returns error? {
     byte[] encoded = check ser.serialize(true);
 
     Proto3SerDes des = check new(boolean);
-    boolean decoded = <boolean>check des.deserialize(encoded);
+    boolean decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, true);
 }
 
@@ -107,7 +107,7 @@ public isolated function testPrimitiveString() returns error? {
     byte[] encoded = check ser.serialize("module-ballerina-serdes");
 
     Proto3SerDes des = check new(string);
-    string decoded = <string>check des.deserialize(encoded);
+    string decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, "module-ballerina-serdes");
 }
 
@@ -117,7 +117,7 @@ public isolated function testPrimitiveInt() returns error? {
     byte[] encoded = check ser.serialize(666);
 
     Proto3SerDes des = check new(int);
-    int decoded = <int>check des.deserialize(encoded);
+    int decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, 666);
 }
 
@@ -127,7 +127,7 @@ public isolated function testStringArray() returns error? {
     byte[] encoded = check ser.serialize(["Jane", "Doe"]);
 
     Proto3SerDes des = check new(StringArray);
-    StringArray decoded = <StringArray>check des.deserialize(encoded);
+    StringArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, ["Jane", "Doe"]);
 }
 
@@ -137,7 +137,7 @@ public isolated function testIntArray() returns error? {
     byte[] encoded = check ser.serialize([1, 2, 3]);
 
     Proto3SerDes des = check new(IntArray);
-    IntArray decoded = <IntArray>check des.deserialize(encoded);
+    IntArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, [1, 2, 3]);
 }
 
@@ -147,7 +147,7 @@ public isolated function testByteArray() returns error? {
     byte[] encoded = check ser.serialize(base16 `aeeecdefabcd12345567888822`);
 
     Proto3SerDes des = check new(ByteArray);
-    ByteArray decoded = <ByteArray>check des.deserialize(encoded);
+    ByteArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, [174,238,205,239,171,205,18,52,85,103,136,136,34]);
 }
 
@@ -157,7 +157,7 @@ public isolated function testFloatArray() returns error? {
     byte[] encoded = check ser.serialize([0.123, 4.968, 3.256]);
 
     Proto3SerDes des = check new(FloatArray);
-    FloatArray decoded = <FloatArray>check des.deserialize(encoded);
+    FloatArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, [0.123, 4.968, 3.256]);
 }
 
@@ -167,7 +167,7 @@ public isolated function testDecimalArray() returns error? {
     byte[] encoded = check ser.serialize([0.123, 4.968, 3.256]);
 
     Proto3SerDes des = check new(DecimalArray);
-    FloatArray decoded = <FloatArray>check des.deserialize(encoded);
+    FloatArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, [0.123, 4.968, 3.256]);
 }
 
@@ -177,7 +177,7 @@ public isolated function testBooleanArray() returns error? {
     byte[] encoded = check ser.serialize([true, false, true, false]);
 
     Proto3SerDes des = check new(BoolArray);
-    BoolArray decoded = <BoolArray>check des.deserialize(encoded);
+    BoolArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, [true, false, true, false]);
 }
 
@@ -194,7 +194,7 @@ public isolated function testNestedArray() returns error? {
     byte[] encoded = check ser.serialize(I);
 
     Proto3SerDes des = check new(OuterArray);
-    OuterArray decoded = <OuterArray>check des.deserialize(encoded);
+    OuterArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, I);
 }
 
@@ -206,7 +206,7 @@ public isolated function testRecordWithPrimitives() returns error? {
     byte[] encoded = check ser.serialize(primitiveRecord);
 
     Proto3SerDes des = check new(Primitive);
-    Primitive decoded = <Primitive>check des.deserialize(encoded);
+    Primitive decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, primitiveRecord);
 }
 
@@ -224,7 +224,7 @@ public isolated function testRecordWithArrays() returns error? {
     byte[] encoded = check ser.serialize(arrayRecord);
 
     Proto3SerDes des = check new(Arrays);
-    Arrays decoded = <Arrays>check des.deserialize(encoded);
+    Arrays decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, arrayRecord);
 }
 
@@ -238,7 +238,7 @@ public isolated function testNestedRecord() returns error? {
     byte[] encoded = check ser.serialize(president);
 
     Proto3SerDes des = check new(Person);
-    Person decoded = <Person>check des.deserialize(encoded);
+    Person decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, president);
 }
 
@@ -252,7 +252,7 @@ public isolated function testArrayOfRecords() returns error? {
     byte[] encoded = check ser.serialize(contacts);
 
     Proto3SerDes des = check new(RecordArray);
-    RecordArray|error decoded = (check des.deserialize(encoded)).cloneWithType(RecordArray);
+    RecordArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, contacts);
 }
 
@@ -270,7 +270,7 @@ public isolated function testComplexRecord() returns error? {
     byte[] encoded = check ser.serialize(john);
 
     Proto3SerDes des = check new(Student);
-    Student decoded = <Student>check des.deserialize(encoded);
+    Student decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, john);
 }
 
@@ -290,7 +290,7 @@ public isolated function testRecordWithNil() returns error? {
     byte[] encoded = check ser.serialize(member2);
 
     Proto3SerDes des = check new(Member);
-    Member decoded = <Member>check des.deserialize(encoded);
+    Member decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, member2);
 }
 
@@ -302,7 +302,7 @@ public isolated function testFieldWithNil() returns error? {
     byte[] encoded = check ser.serialize(());
 
     Proto3SerDes des = check new(DecimalOrNil);
-    DecimalOrNil decoded = <DecimalOrNil>check des.deserialize(encoded);
+    DecimalOrNil decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, ());
 }
 
@@ -314,7 +314,7 @@ public isolated function testUnionField() returns error? {
     byte[] encoded = check ser.serialize(128);
 
     Proto3SerDes des = check new(Union);
-    Union decoded = <Union>check des.deserialize(encoded);
+    Union decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, 128);
 }
 
@@ -328,7 +328,7 @@ public isolated function testUnionWithArrays() returns error? {
     byte[] encoded = check ser.serialize(nums);
 
     Proto3SerDes des = check new(UnionWithArrays);
-    UnionWithArrays decoded = <UnionWithArrays>check des.deserialize(encoded);
+    UnionWithArrays decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, nums);
 }
 
@@ -347,7 +347,7 @@ public isolated function testUnionWithRecord() returns error? {
     byte[] encoded = check ser.serialize(member);
 
     Proto3SerDes des = check new(UnionWithRecord);
-    UnionWithRecord decoded = <UnionWithRecord>check des.deserialize(encoded);
+    UnionWithRecord decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, member);
 }
 
@@ -363,7 +363,7 @@ public isolated function testArrayOfUnionElements() returns error? {
     byte[] encoded = check ser.serialize(array);
 
     Proto3SerDes des = check new(UnionArray);
-    UnionArray decoded = <UnionArray>check des.deserialize(encoded);
+    UnionArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, array);
 }
 
@@ -381,7 +381,7 @@ public isolated function testRecordWithUnionFields() returns error? {
     byte[] encoded = check ser.serialize(rec);
 
     Proto3SerDes des = check new(RecordWithUnionFields);
-    RecordWithUnionFields decoded = <RecordWithUnionFields>check des.deserialize(encoded);
+    RecordWithUnionFields decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, rec);
 }
 
@@ -402,7 +402,7 @@ public isolated function testNestedArrayWithUnionFields() returns error? {
     byte[] encoded = check ser.serialize(level2Array);
 
     Proto3SerDes des = check new(Level1Array);
-    Level1Array decoded = <Level1Array>check des.deserialize(encoded);
+    Level1Array decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, level2Array);
 }
 
@@ -436,7 +436,7 @@ public isolated function testComplexTypeWithUnion() returns error? {
     byte[] encoded = check ser.serialize(randomRecord);
 
     Proto3SerDes des = check new(MyRecord);
-    MyRecord decoded = <MyRecord>check des.deserialize(encoded);
+    MyRecord decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, randomRecord);
 }
 
@@ -448,7 +448,7 @@ public isolated function testUnionTypeWithNull() returns error? {
     byte[] encoded = check ser.serialize(nullType);
 
     Proto3SerDes des = check new(IntStringOrNull);
-    IntStringOrNull decoded = <IntStringOrNull>check des.deserialize(encoded);
+    IntStringOrNull decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, nullType);
 }
 
@@ -476,7 +476,7 @@ public isolated function testUseCase1() returns error? {
     byte[] encoded = check ser.serialize(employer);
 
     Proto3SerDes des = check new(Individual);
-    Individual decoded = <Individual>check des.deserialize(encoded);
+    Individual decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, employer);
 }
 
@@ -497,6 +497,6 @@ public isolated function simpleTest() returns error? {
     byte[] encoded = check ser.serialize(p);
 
     Proto3SerDes des = check new(President);
-    President decoded = <President>check des.deserialize(encoded);
+    President decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, p);
 }

--- a/ballerina/tests/unit_tests.bal
+++ b/ballerina/tests/unit_tests.bal
@@ -73,110 +73,110 @@ type RecordArray Contact[];
 
 @test:Config{}
 public isolated function testPrimitiveFloat() returns error? {
-    Proto3SerDes ser = check new(float);
+    Proto3Schema ser = check new(float);
     byte[] encoded = check ser.serialize(6.666);
 
-    Proto3SerDes des = check new(float);
+    Proto3Schema des = check new(float);
     float decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, 6.666);
 }
 
 @test:Config{}
 public isolated function testPrimitiveDecimal() returns error? {
-    Proto3SerDes ser = check new(decimal);
+    Proto3Schema ser = check new(decimal);
     byte[] encoded = check ser.serialize(1.23);
 
-    Proto3SerDes des = check new(decimal);
+    Proto3Schema des = check new(decimal);
     float decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, 1.23);
 }
 
 @test:Config{}
 public isolated function testPrimitiveBoolean() returns error? {
-    Proto3SerDes ser = check new(boolean);
+    Proto3Schema ser = check new(boolean);
     byte[] encoded = check ser.serialize(true);
 
-    Proto3SerDes des = check new(boolean);
+    Proto3Schema des = check new(boolean);
     boolean decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, true);
 }
 
 @test:Config{}
 public isolated function testPrimitiveString() returns error? {
-    Proto3SerDes ser = check new(string);
+    Proto3Schema ser = check new(string);
     byte[] encoded = check ser.serialize("module-ballerina-serdes");
 
-    Proto3SerDes des = check new(string);
+    Proto3Schema des = check new(string);
     string decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, "module-ballerina-serdes");
 }
 
 @test:Config{}
 public isolated function testPrimitiveInt() returns error? {
-    Proto3SerDes ser = check new(int);
+    Proto3Schema ser = check new(int);
     byte[] encoded = check ser.serialize(666);
 
-    Proto3SerDes des = check new(int);
+    Proto3Schema des = check new(int);
     int decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, 666);
 }
 
 @test:Config{}
 public isolated function testStringArray() returns error? {
-    Proto3SerDes ser = check new(StringArray);
+    Proto3Schema ser = check new(StringArray);
     byte[] encoded = check ser.serialize(["Jane", "Doe"]);
 
-    Proto3SerDes des = check new(StringArray);
+    Proto3Schema des = check new(StringArray);
     StringArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, ["Jane", "Doe"]);
 }
 
 @test:Config{}
 public isolated function testIntArray() returns error? {
-    Proto3SerDes ser = check new(IntArray);
+    Proto3Schema ser = check new(IntArray);
     byte[] encoded = check ser.serialize([1, 2, 3]);
 
-    Proto3SerDes des = check new(IntArray);
+    Proto3Schema des = check new(IntArray);
     IntArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, [1, 2, 3]);
 }
 
 @test:Config{}
 public isolated function testByteArray() returns error? {
-    Proto3SerDes ser = check new(ByteArray);
+    Proto3Schema ser = check new(ByteArray);
     byte[] encoded = check ser.serialize(base16 `aeeecdefabcd12345567888822`);
 
-    Proto3SerDes des = check new(ByteArray);
+    Proto3Schema des = check new(ByteArray);
     ByteArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, [174,238,205,239,171,205,18,52,85,103,136,136,34]);
 }
 
 @test:Config{}
 public isolated function testFloatArray() returns error? {
-    Proto3SerDes ser = check new(FloatArray);
+    Proto3Schema ser = check new(FloatArray);
     byte[] encoded = check ser.serialize([0.123, 4.968, 3.256]);
 
-    Proto3SerDes des = check new(FloatArray);
+    Proto3Schema des = check new(FloatArray);
     FloatArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, [0.123, 4.968, 3.256]);
 }
 
 @test:Config{}
 public isolated function testDecimalArray() returns error? {
-    Proto3SerDes ser = check new(DecimalArray);
+    Proto3Schema ser = check new(DecimalArray);
     byte[] encoded = check ser.serialize([0.123, 4.968, 3.256]);
 
-    Proto3SerDes des = check new(DecimalArray);
+    Proto3Schema des = check new(DecimalArray);
     FloatArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, [0.123, 4.968, 3.256]);
 }
 
 @test:Config{}
 public isolated function testBooleanArray() returns error? {
-    Proto3SerDes ser = check new(BoolArray);
+    Proto3Schema ser = check new(BoolArray);
     byte[] encoded = check ser.serialize([true, false, true, false]);
 
-    Proto3SerDes des = check new(BoolArray);
+    Proto3Schema des = check new(BoolArray);
     BoolArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, [true, false, true, false]);
 }
@@ -190,10 +190,10 @@ public isolated function testNestedArray() returns error? {
     InnerArray i2 = [4, 5, 6];
     OuterArray I = [i1, i2];
 
-    Proto3SerDes ser = check new(OuterArray);
+    Proto3Schema ser = check new(OuterArray);
     byte[] encoded = check ser.serialize(I);
 
-    Proto3SerDes des = check new(OuterArray);
+    Proto3Schema des = check new(OuterArray);
     OuterArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, I);
 }
@@ -202,10 +202,10 @@ public isolated function testNestedArray() returns error? {
 public isolated function testRecordWithPrimitives() returns error? {
     Primitive primitiveRecord = { stringValue: "serdes", intValue: 192, floatValue: 192.168, boolValue: false };
 
-    Proto3SerDes ser = check new(Primitive);
+    Proto3Schema ser = check new(Primitive);
     byte[] encoded = check ser.serialize(primitiveRecord);
 
-    Proto3SerDes des = check new(Primitive);
+    Proto3Schema des = check new(Primitive);
     Primitive decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, primitiveRecord);
 }
@@ -220,10 +220,10 @@ public isolated function testRecordWithArrays() returns error? {
         byteArray: base16 `aeeecdefabcd12345567888822`
     };
 
-    Proto3SerDes ser = check new(Arrays);
+    Proto3Schema ser = check new(Arrays);
     byte[] encoded = check ser.serialize(arrayRecord);
 
-    Proto3SerDes des = check new(Arrays);
+    Proto3Schema des = check new(Arrays);
     Arrays decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, arrayRecord);
 }
@@ -234,10 +234,10 @@ public isolated function testNestedRecord() returns error? {
     Contact phone = {mobile: "+94111111111", home: "+94777777777"};
     Person president = { name: "Joe",  age:70, img:byteArray, random:1.666, contact:phone };
 
-    Proto3SerDes ser = check new(Person);
+    Proto3Schema ser = check new(Person);
     byte[] encoded = check ser.serialize(president);
 
-    Proto3SerDes des = check new(Person);
+    Proto3Schema des = check new(Person);
     Person decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, president);
 }
@@ -248,10 +248,10 @@ public isolated function testArrayOfRecords() returns error? {
     Contact phone2 = {mobile: "+456789", home: "123"};
     Contact[] contacts = [phone1, phone2];
 
-    Proto3SerDes ser = check new(RecordArray);
+    Proto3Schema ser = check new(RecordArray);
     byte[] encoded = check ser.serialize(contacts);
 
-    Proto3SerDes des = check new(RecordArray);
+    Proto3Schema des = check new(RecordArray);
     RecordArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, contacts);
 }
@@ -266,10 +266,10 @@ public isolated function testComplexRecord() returns error? {
     Contact[] nums = [phone1, phone2];
     Student john = { name: "John Doe", age: 21, img: byteArray, contacts: nums, address: address };
 
-    Proto3SerDes ser = check new(Student);
+    Proto3Schema ser = check new(Student);
     byte[] encoded = check ser.serialize(john);
 
-    Proto3SerDes des = check new(Student);
+    Proto3Schema des = check new(Student);
     Student decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, john);
 }
@@ -286,10 +286,10 @@ public isolated function testRecordWithNil() returns error? {
     // Member member1 = {name: "foo", salary: 1.23, contact: phone1};
     Member member2 = {name: "bar", salary:()};
 
-    Proto3SerDes ser = check new(Member);
+    Proto3Schema ser = check new(Member);
     byte[] encoded = check ser.serialize(member2);
 
-    Proto3SerDes des = check new(Member);
+    Proto3Schema des = check new(Member);
     Member decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, member2);
 }
@@ -298,10 +298,10 @@ type DecimalOrNil decimal?;
 
 @test:Config{}
 public isolated function testFieldWithNil() returns error? {
-    Proto3SerDes ser = check new(DecimalOrNil);
+    Proto3Schema ser = check new(DecimalOrNil);
     byte[] encoded = check ser.serialize(());
 
-    Proto3SerDes des = check new(DecimalOrNil);
+    Proto3Schema des = check new(DecimalOrNil);
     DecimalOrNil decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, ());
 }
@@ -310,10 +310,10 @@ type Union int|string|boolean|();
 
 @test:Config{}
 public isolated function testUnionField() returns error? {
-    Proto3SerDes ser = check new(Union);
+    Proto3Schema ser = check new(Union);
     byte[] encoded = check ser.serialize(128);
 
-    Proto3SerDes des = check new(Union);
+    Proto3Schema des = check new(Union);
     Union decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, 128);
 }
@@ -324,10 +324,10 @@ type UnionWithArrays int[]|string[]|boolean;
 public isolated function testUnionWithArrays() returns error? {
     int[] nums = [1, 9, 2, 1, 6, 8];
 
-    Proto3SerDes ser = check new(UnionWithArrays);
+    Proto3Schema ser = check new(UnionWithArrays);
     byte[] encoded = check ser.serialize(nums);
 
-    Proto3SerDes des = check new(UnionWithArrays);
+    Proto3Schema des = check new(UnionWithArrays);
     UnionWithArrays decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, nums);
 }
@@ -343,10 +343,10 @@ type UnionWithRecord int|string[]|UnionMember|();
 public isolated function testUnionWithRecord() returns error? {
     UnionMember member = { name: "Jane", id:100 };
 
-    Proto3SerDes ser = check new(UnionWithRecord);
+    Proto3Schema ser = check new(UnionWithRecord);
     byte[] encoded = check ser.serialize(member);
 
-    Proto3SerDes des = check new(UnionWithRecord);
+    Proto3Schema des = check new(UnionWithRecord);
     UnionWithRecord decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, member);
 }
@@ -359,10 +359,10 @@ public isolated function testArrayOfUnionElements() returns error? {
     UnionMember member = { name: "Jane", id:100 };
     UnionElement[] array = [1, 2, ["John", "Doe"], member];
 
-    Proto3SerDes ser = check new(UnionArray);
+    Proto3Schema ser = check new(UnionArray);
     byte[] encoded = check ser.serialize(array);
 
-    Proto3SerDes des = check new(UnionArray);
+    Proto3Schema des = check new(UnionArray);
     UnionArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, array);
 }
@@ -377,10 +377,10 @@ public isolated function testRecordWithUnionFields() returns error? {
     // UnionMember member = { name: "Jane Doe", id:100 };
     RecordWithUnionFields rec = { name: "Jane", membership: () };
 
-    Proto3SerDes ser = check new(RecordWithUnionFields);
+    Proto3Schema ser = check new(RecordWithUnionFields);
     byte[] encoded = check ser.serialize(rec);
 
-    Proto3SerDes des = check new(RecordWithUnionFields);
+    Proto3Schema des = check new(RecordWithUnionFields);
     RecordWithUnionFields decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, rec);
 }
@@ -398,10 +398,10 @@ public isolated function testNestedArrayWithUnionFields() returns error? {
     Level3Array[] level3Array = [uType, uType2];
     Level2Array[] level2Array = [level3Array];
 
-    Proto3SerDes ser = check new(Level1Array);
+    Proto3Schema ser = check new(Level1Array);
     byte[] encoded = check ser.serialize(level2Array);
 
-    Proto3SerDes des = check new(Level1Array);
+    Proto3Schema des = check new(Level1Array);
     Level1Array decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, level2Array);
 }
@@ -432,10 +432,10 @@ public isolated function testComplexTypeWithUnion() returns error? {
     RecordWithUnion membership = {member_id: 619};
     MyRecord randomRecord = {name: "John", test_type: member1, member: membership};
 
-    Proto3SerDes ser = check new(MyRecord);
+    Proto3Schema ser = check new(MyRecord);
     byte[] encoded = check ser.serialize(randomRecord);
 
-    Proto3SerDes des = check new(MyRecord);
+    Proto3Schema des = check new(MyRecord);
     MyRecord decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, randomRecord);
 }
@@ -444,10 +444,10 @@ public isolated function testComplexTypeWithUnion() returns error? {
 public isolated function testUnionTypeWithNull() returns error? {
     IntStringOrNull nullType = ();
 
-    Proto3SerDes ser = check new(IntStringOrNull);
+    Proto3Schema ser = check new(IntStringOrNull);
     byte[] encoded = check ser.serialize(nullType);
 
-    Proto3SerDes des = check new(IntStringOrNull);
+    Proto3Schema des = check new(IntStringOrNull);
     IntStringOrNull decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, nullType);
 }
@@ -472,10 +472,10 @@ public isolated function testUseCase1() returns error? {
     byte[] byteArray = base16 `aeeecdefabcd12345567888822`;
     Employer employer = {name: "John Doe", id: 101, img: byteArray};
 
-    Proto3SerDes ser = check new(Individual);
+    Proto3Schema ser = check new(Individual);
     byte[] encoded = check ser.serialize(employer);
 
-    Proto3SerDes des = check new(Individual);
+    Proto3Schema des = check new(Individual);
     Individual decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, employer);
 }
@@ -493,10 +493,10 @@ type President record {
 public isolated function simpleTest() returns error? {
     President p = {name: "John Doe", contact: {mobile: "123456"}};
 
-    Proto3SerDes ser = check new(President);
+    Proto3Schema ser = check new(President);
     byte[] encoded = check ser.serialize(p);
 
-    Proto3SerDes des = check new(President);
+    Proto3Schema des = check new(President);
     President decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, p);
 }

--- a/native/src/main/java/io/ballerina/stdlib/serdes/Serializer.java
+++ b/native/src/main/java/io/ballerina/stdlib/serdes/Serializer.java
@@ -24,6 +24,7 @@ import com.google.protobuf.DynamicMessage;
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BMap;
@@ -62,6 +63,8 @@ public class Serializer {
     static final String SERIALIZATION_ERROR_MESSAGE = "Failed to Serialize data: ";
     static final String TYPE_MISMATCH_ERROR_MESSAGE = "Type mismatch";
 
+    static final BString BALLERINA_TYPEDESC_ATTRIBUTE_NAME = StringUtils.fromString("dataType");
+
     /**
      * Creates a BArray for given data after serializing.
      *
@@ -69,7 +72,8 @@ public class Serializer {
      * @param message Data that is being serialized.
      * @return Byte array of the serialized value.
      */
-    public static Object serialize(BObject serializer, Object message, BTypedesc dataType) {
+    public static Object serialize(BObject serializer, Object message) {
+        BTypedesc dataType = (BTypedesc) serializer.get(BALLERINA_TYPEDESC_ATTRIBUTE_NAME);
         Descriptor schema = (Descriptor) serializer.getNativeData(SCHEMA_NAME);
         DynamicMessage dynamicMessage;
         try {


### PR DESCRIPTION
## Purpose

- Add type inference to avoid casting
- Refactor SerDes object name to Schema 


## Examples
```ballerina
Person president = { name: "Joe",  age:70 };

serdes:Schema schema = check new Proto3Schema(Person);

byte[] encoded = check schema.serialize(president);

// before 
// Person 'president = <Person> check schema.deserialize(encoded);

// now casting removed with type inference
Person 'president = check schema.deserialize(encoded);
```