### PR TITLE
Add support to decimal type

### DIFF
--- a/ballerina/tests/primitive_type_test.bal
+++ b/ballerina/tests/primitive_type_test.bal
@@ -1,0 +1,77 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+@test:Config {}
+public isolated function testPrimitiveInt() returns error? {
+    int value = 666;
+
+    Proto3Schema ser = check new (int);
+    byte[] encoded = check ser.serialize(value);
+
+    Proto3Schema des = check new (int);
+    int decoded = check des.deserialize(encoded);
+    test:assertEquals(decoded, value);
+}
+
+@test:Config {}
+public isolated function testPrimitiveBoolean() returns error? {
+    boolean value = true;
+
+    Proto3Schema ser = check new (boolean);
+    byte[] encoded = check ser.serialize(value);
+
+    Proto3Schema des = check new (boolean);
+    boolean decoded = check des.deserialize(encoded);
+    test:assertEquals(decoded, value);
+}
+
+@test:Config {}
+public isolated function testPrimitiveFloat() returns error? {
+    float value = 6.666;
+
+    Proto3Schema ser = check new (float);
+    byte[] encoded = check ser.serialize(value);
+
+    Proto3Schema des = check new (float);
+    float decoded = check des.deserialize(encoded);
+    test:assertEquals(decoded, value);
+}
+
+@test:Config {}
+public isolated function testPrimitiveDecimal() returns error? {
+    decimal value = 1d / 100000d;
+
+    Proto3Schema ser = check new (decimal);
+    byte[] encoded = check ser.serialize(value);
+
+    Proto3Schema des = check new (decimal);
+    decimal decoded = check des.deserialize(encoded);
+    test:assertEquals(decoded, value);
+}
+
+@test:Config {}
+public isolated function testPrimitiveString() returns error? {
+    string value = "module-ballerina-serdes";
+
+    Proto3Schema ser = check new (string);
+    byte[] encoded = check ser.serialize(value);
+
+    Proto3Schema des = check new (string);
+    string decoded = check des.deserialize(encoded);
+    test:assertEquals(decoded, value);
+}

--- a/ballerina/tests/structure_type_test.bal
+++ b/ballerina/tests/structure_type_test.bal
@@ -32,19 +32,19 @@ type Address record {
 };
 
 type Person record {
-   string name;
-   int age;
-   byte[] img;
-   float random;
-   Contact contact;
+    string name;
+    int age;
+    byte[] img;
+    float random;
+    Contact contact;
 };
 
 type Student record {
-   string name;
-   int age;
-   byte[] img;
-   Contact[] contacts;
-   Address address;
+    string name;
+    int age;
+    byte[] img;
+    Contact[] contacts;
+    Address address;
 };
 
 type Primitive record {
@@ -63,154 +63,100 @@ type Arrays record {
 };
 
 type StringArray string[];
+
 type IntArray int[];
+
 type ByteArray byte[];
+
 type FloatArray float[];
+
 type DecimalArray float[];
+
 type BoolArray boolean[];
 
 type RecordArray Contact[];
 
-@test:Config{}
-public isolated function testPrimitiveFloat() returns error? {
-    Proto3Schema ser = check new(float);
-    byte[] encoded = check ser.serialize(6.666);
-
-    Proto3Schema des = check new(float);
-    float decoded = check des.deserialize(encoded);
-    test:assertEquals(decoded, 6.666);
-}
-
-@test:Config{}
-public isolated function testPrimitiveDecimal() returns error? {
-    Proto3Schema ser = check new(decimal);
-    byte[] encoded = check ser.serialize(1.23);
-
-    Proto3Schema des = check new(decimal);
-    float decoded = check des.deserialize(encoded);
-    test:assertEquals(decoded, 1.23);
-}
-
-@test:Config{}
-public isolated function testPrimitiveBoolean() returns error? {
-    Proto3Schema ser = check new(boolean);
-    byte[] encoded = check ser.serialize(true);
-
-    Proto3Schema des = check new(boolean);
-    boolean decoded = check des.deserialize(encoded);
-    test:assertEquals(decoded, true);
-}
-
-@test:Config{}
-public isolated function testPrimitiveString() returns error? {
-    Proto3Schema ser = check new(string);
-    byte[] encoded = check ser.serialize("module-ballerina-serdes");
-
-    Proto3Schema des = check new(string);
-    string decoded = check des.deserialize(encoded);
-    test:assertEquals(decoded, "module-ballerina-serdes");
-}
-
-@test:Config{}
-public isolated function testPrimitiveInt() returns error? {
-    Proto3Schema ser = check new(int);
-    byte[] encoded = check ser.serialize(666);
-
-    Proto3Schema des = check new(int);
-    int decoded = check des.deserialize(encoded);
-    test:assertEquals(decoded, 666);
-}
-
-@test:Config{}
+@test:Config {}
 public isolated function testStringArray() returns error? {
-    Proto3Schema ser = check new(StringArray);
+    Proto3Schema ser = check new (StringArray);
     byte[] encoded = check ser.serialize(["Jane", "Doe"]);
 
-    Proto3Schema des = check new(StringArray);
+    Proto3Schema des = check new (StringArray);
     StringArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, ["Jane", "Doe"]);
 }
 
-@test:Config{}
+@test:Config {}
 public isolated function testIntArray() returns error? {
-    Proto3Schema ser = check new(IntArray);
+    Proto3Schema ser = check new (IntArray);
     byte[] encoded = check ser.serialize([1, 2, 3]);
 
-    Proto3Schema des = check new(IntArray);
+    Proto3Schema des = check new (IntArray);
     IntArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, [1, 2, 3]);
 }
 
-@test:Config{}
+@test:Config {}
 public isolated function testByteArray() returns error? {
-    Proto3Schema ser = check new(ByteArray);
+    Proto3Schema ser = check new (ByteArray);
     byte[] encoded = check ser.serialize(base16 `aeeecdefabcd12345567888822`);
 
-    Proto3Schema des = check new(ByteArray);
+    Proto3Schema des = check new (ByteArray);
     ByteArray decoded = check des.deserialize(encoded);
-    test:assertEquals(decoded, [174,238,205,239,171,205,18,52,85,103,136,136,34]);
+    test:assertEquals(decoded, [174, 238, 205, 239, 171, 205, 18, 52, 85, 103, 136, 136, 34]);
 }
 
-@test:Config{}
+@test:Config {}
 public isolated function testFloatArray() returns error? {
-    Proto3Schema ser = check new(FloatArray);
+    Proto3Schema ser = check new (FloatArray);
     byte[] encoded = check ser.serialize([0.123, 4.968, 3.256]);
 
-    Proto3Schema des = check new(FloatArray);
+    Proto3Schema des = check new (FloatArray);
     FloatArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, [0.123, 4.968, 3.256]);
 }
 
-@test:Config{}
-public isolated function testDecimalArray() returns error? {
-    Proto3Schema ser = check new(DecimalArray);
-    byte[] encoded = check ser.serialize([0.123, 4.968, 3.256]);
-
-    Proto3Schema des = check new(DecimalArray);
-    FloatArray decoded = check des.deserialize(encoded);
-    test:assertEquals(decoded, [0.123, 4.968, 3.256]);
-}
-
-@test:Config{}
+@test:Config {}
 public isolated function testBooleanArray() returns error? {
-    Proto3Schema ser = check new(BoolArray);
+    Proto3Schema ser = check new (BoolArray);
     byte[] encoded = check ser.serialize([true, false, true, false]);
 
-    Proto3Schema des = check new(BoolArray);
+    Proto3Schema des = check new (BoolArray);
     BoolArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, [true, false, true, false]);
 }
 
 type InnerArray int[];
+
 type OuterArray InnerArray[];
 
-@test:Config{}
+@test:Config {}
 public isolated function testNestedArray() returns error? {
     InnerArray i1 = [1, 2, 3];
     InnerArray i2 = [4, 5, 6];
     OuterArray I = [i1, i2];
 
-    Proto3Schema ser = check new(OuterArray);
+    Proto3Schema ser = check new (OuterArray);
     byte[] encoded = check ser.serialize(I);
 
-    Proto3Schema des = check new(OuterArray);
+    Proto3Schema des = check new (OuterArray);
     OuterArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, I);
 }
 
-@test:Config{}
+@test:Config {}
 public isolated function testRecordWithPrimitives() returns error? {
-    Primitive primitiveRecord = { stringValue: "serdes", intValue: 192, floatValue: 192.168, boolValue: false };
+    Primitive primitiveRecord = {stringValue: "serdes", intValue: 192, floatValue: 192.168, boolValue: false};
 
-    Proto3Schema ser = check new(Primitive);
+    Proto3Schema ser = check new (Primitive);
     byte[] encoded = check ser.serialize(primitiveRecord);
 
-    Proto3Schema des = check new(Primitive);
+    Proto3Schema des = check new (Primitive);
     Primitive decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, primitiveRecord);
 }
 
-@test:Config{}
+@test:Config {}
 public isolated function testRecordWithArrays() returns error? {
     Arrays arrayRecord = {
         stringArray: ["Jane", "Doe"],
@@ -220,56 +166,56 @@ public isolated function testRecordWithArrays() returns error? {
         byteArray: base16 `aeeecdefabcd12345567888822`
     };
 
-    Proto3Schema ser = check new(Arrays);
+    Proto3Schema ser = check new (Arrays);
     byte[] encoded = check ser.serialize(arrayRecord);
 
-    Proto3Schema des = check new(Arrays);
+    Proto3Schema des = check new (Arrays);
     Arrays decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, arrayRecord);
 }
 
-@test:Config{}
+@test:Config {}
 public isolated function testNestedRecord() returns error? {
     byte[] byteArray = base16 `aeeecdefabcd12345567888822`;
     Contact phone = {mobile: "+94111111111", home: "+94777777777"};
-    Person president = { name: "Joe",  age:70, img:byteArray, random:1.666, contact:phone };
+    Person president = {name: "Joe", age: 70, img: byteArray, random: 1.666, contact: phone};
 
-    Proto3Schema ser = check new(Person);
+    Proto3Schema ser = check new (Person);
     byte[] encoded = check ser.serialize(president);
 
-    Proto3Schema des = check new(Person);
+    Proto3Schema des = check new (Person);
     Person decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, president);
 }
 
-@test:Config{}
+@test:Config {}
 public isolated function testArrayOfRecords() returns error? {
     Contact phone1 = {mobile: "+123456", home: "789"};
     Contact phone2 = {mobile: "+456789", home: "123"};
     Contact[] contacts = [phone1, phone2];
 
-    Proto3Schema ser = check new(RecordArray);
+    Proto3Schema ser = check new (RecordArray);
     byte[] encoded = check ser.serialize(contacts);
 
-    Proto3Schema des = check new(RecordArray);
+    Proto3Schema des = check new (RecordArray);
     RecordArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, contacts);
 }
 
-@test:Config{}
+@test:Config {}
 public isolated function testComplexRecord() returns error? {
     byte[] byteArray = base16 `aeeecdefabcd12345567888822`;
     Contact phone1 = {mobile: "+123456", home: "789"};
     Contact phone2 = {mobile: "+456789", home: "123"};
-    Street street = { street1: "random lane", street2: "random street" };
-    Address address = { street: street, country: "Sri Lanka" };
+    Street street = {street1: "random lane", street2: "random street"};
+    Address address = {street: street, country: "Sri Lanka"};
     Contact[] nums = [phone1, phone2];
-    Student john = { name: "John Doe", age: 21, img: byteArray, contacts: nums, address: address };
+    Student john = {name: "John Doe", age: 21, img: byteArray, contacts: nums, address: address};
 
-    Proto3Schema ser = check new(Student);
+    Proto3Schema ser = check new (Student);
     byte[] encoded = check ser.serialize(john);
 
-    Proto3Schema des = check new(Student);
+    Proto3Schema des = check new (Student);
     Student decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, john);
 }
@@ -280,52 +226,54 @@ type Member record {
     Contact contact?;
 };
 
-@test:Config{}
+@test:Config {}
 public isolated function testRecordWithNil() returns error? {
-    Member member2 = {name: "bar", salary:()};
+    // Contact phone1 = {mobile: "+123456", home: "789"};
+    // Member member1 = {name: "foo", salary: 1.23, contact: phone1};
+    Member member2 = {name: "bar", salary: ()};
 
-    Proto3Schema ser = check new(Member);
+    Proto3Schema ser = check new (Member);
     byte[] encoded = check ser.serialize(member2);
 
-    Proto3Schema des = check new(Member);
+    Proto3Schema des = check new (Member);
     Member decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, member2);
 }
 
 type DecimalOrNil decimal?;
 
-@test:Config{}
+@test:Config {}
 public isolated function testFieldWithNil() returns error? {
-    Proto3Schema ser = check new(DecimalOrNil);
+    Proto3Schema ser = check new (DecimalOrNil);
     byte[] encoded = check ser.serialize(());
 
-    Proto3Schema des = check new(DecimalOrNil);
+    Proto3Schema des = check new (DecimalOrNil);
     DecimalOrNil decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, ());
 }
 
 type Union int|string|boolean|();
 
-@test:Config{}
+@test:Config {}
 public isolated function testUnionField() returns error? {
-    Proto3Schema ser = check new(Union);
+    Proto3Schema ser = check new (Union);
     byte[] encoded = check ser.serialize(128);
 
-    Proto3Schema des = check new(Union);
+    Proto3Schema des = check new (Union);
     Union decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, 128);
 }
 
 type UnionWithArrays int[]|string[]|boolean;
 
-@test:Config{}
+@test:Config {}
 public isolated function testUnionWithArrays() returns error? {
     int[] nums = [1, 9, 2, 1, 6, 8];
 
-    Proto3Schema ser = check new(UnionWithArrays);
+    Proto3Schema ser = check new (UnionWithArrays);
     byte[] encoded = check ser.serialize(nums);
 
-    Proto3Schema des = check new(UnionWithArrays);
+    Proto3Schema des = check new (UnionWithArrays);
     UnionWithArrays decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, nums);
 }
@@ -337,30 +285,31 @@ type UnionMember record {
 
 type UnionWithRecord int|string[]|UnionMember|();
 
-@test:Config{}
+@test:Config {}
 public isolated function testUnionWithRecord() returns error? {
-    UnionMember member = { name: "Jane", id:100 };
+    UnionMember member = {name: "Jane", id: 100};
 
-    Proto3Schema ser = check new(UnionWithRecord);
+    Proto3Schema ser = check new (UnionWithRecord);
     byte[] encoded = check ser.serialize(member);
 
-    Proto3Schema des = check new(UnionWithRecord);
+    Proto3Schema des = check new (UnionWithRecord);
     UnionWithRecord decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, member);
 }
 
 type UnionElement int|string[]|UnionMember|();
+
 type UnionArray UnionElement[];
 
-@test:Config{}
+@test:Config {}
 public isolated function testArrayOfUnionElements() returns error? {
-    UnionMember member = { name: "Jane", id:100 };
+    UnionMember member = {name: "Jane", id: 100};
     UnionElement[] array = [1, 2, ["John", "Doe"], member];
 
-    Proto3Schema ser = check new(UnionArray);
+    Proto3Schema ser = check new (UnionArray);
     byte[] encoded = check ser.serialize(array);
 
-    Proto3Schema des = check new(UnionArray);
+    Proto3Schema des = check new (UnionArray);
     UnionArray decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, array);
 }
@@ -370,24 +319,28 @@ type RecordWithUnionFields record {
     UnionElement membership;
 };
 
-@test:Config{}
+@test:Config {}
 public isolated function testRecordWithUnionFields() returns error? {
-    RecordWithUnionFields rec = { name: "Jane", membership: () };
+    // UnionMember member = { name: "Jane Doe", id:100 };
+    RecordWithUnionFields rec = {name: "Jane", membership: ()};
 
-    Proto3Schema ser = check new(RecordWithUnionFields);
+    Proto3Schema ser = check new (RecordWithUnionFields);
     byte[] encoded = check ser.serialize(rec);
 
-    Proto3Schema des = check new(RecordWithUnionFields);
+    Proto3Schema des = check new (RecordWithUnionFields);
     RecordWithUnionFields decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, rec);
 }
 
 type UnionType int|string[]|TestMember[]|TestMember;
+
 type Level3Array UnionType[];
+
 type Level2Array Level3Array[];
+
 type Level1Array Level2Array[];
 
-@test:Config{}
+@test:Config {}
 public isolated function testNestedArrayWithUnionFields() returns error? {
     TestMember member1 = {full_name: "foo bar", id: 100};
     UnionType[] uType = [1, 2, ["John", "Doe"], member1];
@@ -395,10 +348,10 @@ public isolated function testNestedArrayWithUnionFields() returns error? {
     Level3Array[] level3Array = [uType, uType2];
     Level2Array[] level2Array = [level3Array];
 
-    Proto3Schema ser = check new(Level1Array);
+    Proto3Schema ser = check new (Level1Array);
     byte[] encoded = check ser.serialize(level2Array);
 
-    Proto3Schema des = check new(Level1Array);
+    Proto3Schema des = check new (Level1Array);
     Level1Array decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, level2Array);
 }
@@ -420,28 +373,31 @@ type TestMember record {
     int id;
 };
 
-@test:Config{}
+@test:Config {}
 public isolated function testComplexTypeWithUnion() returns error? {
+    // int[] nums = [1, 2, 3];
     TestMember[] member1 = [{full_name: "foo bar", id: 100}];
+    // UnionType[] uArray = [1, 2, ["Jane", "Doe"], member1];
+    // TestMember member = {full_name: "John Doe", id: 101};
     RecordWithUnion membership = {member_id: 619};
     MyRecord randomRecord = {name: "John", test_type: member1, member: membership};
 
-    Proto3Schema ser = check new(MyRecord);
+    Proto3Schema ser = check new (MyRecord);
     byte[] encoded = check ser.serialize(randomRecord);
 
-    Proto3Schema des = check new(MyRecord);
+    Proto3Schema des = check new (MyRecord);
     MyRecord decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, randomRecord);
 }
 
-@test:Config{}
+@test:Config {}
 public isolated function testUnionTypeWithNull() returns error? {
     IntStringOrNull nullType = ();
 
-    Proto3Schema ser = check new(IntStringOrNull);
+    Proto3Schema ser = check new (IntStringOrNull);
     byte[] encoded = check ser.serialize(nullType);
 
-    Proto3Schema des = check new(IntStringOrNull);
+    Proto3Schema des = check new (IntStringOrNull);
     IntStringOrNull decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, nullType);
 }
@@ -461,15 +417,15 @@ type Employee record {
 
 type Individual Employer|Employee;
 
-@test:Config{}
+@test:Config {}
 public isolated function testUseCase1() returns error? {
     byte[] byteArray = base16 `aeeecdefabcd12345567888822`;
     Employer employer = {name: "John Doe", id: 101, img: byteArray};
 
-    Proto3Schema ser = check new(Individual);
+    Proto3Schema ser = check new (Individual);
     byte[] encoded = check ser.serialize(employer);
 
-    Proto3Schema des = check new(Individual);
+    Proto3Schema des = check new (Individual);
     Individual decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, employer);
 }
@@ -483,14 +439,45 @@ type President record {
     Cont contact;
 };
 
-@test:Config{}
+@test:Config {}
 public isolated function simpleTest() returns error? {
     President p = {name: "John Doe", contact: {mobile: "123456"}};
 
-    Proto3Schema ser = check new(President);
+    Proto3Schema ser = check new (President);
     byte[] encoded = check ser.serialize(p);
 
-    Proto3Schema des = check new(President);
+    Proto3Schema des = check new (President);
     President decoded = check des.deserialize(encoded);
     test:assertEquals(decoded, p);
+}
+
+type Prices decimal[];
+
+@test:Config {}
+public isolated function testDecimalArray() returns error? {
+    Prices value = [100.99d, 49.893d, 478.89d];
+
+    Proto3Schema ser = check new (Prices);
+    byte[] encoded = check ser.serialize(value);
+
+    Proto3Schema des = check new (Prices);
+    Prices decoded = check des.deserialize(encoded);
+    test:assertEquals(decoded, value);
+}
+
+type RecordWithDecimal record {
+    decimal 'decimal;
+    Prices prices;
+};
+
+@test:Config {}
+public isolated function testRecordWithDecimal() returns error? {
+    RecordWithDecimal value = {'decimal: 234.0000000009d, prices: [100.99d, 49.893d, 478.89d]};
+
+    Proto3Schema ser = check new (RecordWithDecimal);
+    byte[] encoded = check ser.serialize(value);
+
+    Proto3Schema des = check new (RecordWithDecimal);
+    RecordWithDecimal decoded = check des.deserialize(encoded);
+    test:assertEquals(decoded, value);
 }

--- a/native/src/main/java/io/ballerina/stdlib/serdes/SchemaGenerator.java
+++ b/native/src/main/java/io/ballerina/stdlib/serdes/SchemaGenerator.java
@@ -94,10 +94,10 @@ public class SchemaGenerator {
 
     private static ProtobufMessage buildProtobufMessageFromBallerinaTypedesc(BTypedesc typedesc) {
         Type type = typedesc.getDescribingType();
-
         if (type.getTag() <= TypeTags.BOOLEAN_TAG) {
             String ballerinaToProtoMap = DataTypeMapper.getProtoTypeFromTag(type.getTag());
-            ProtobufMessageBuilder messageBuilder = ProtobufMessage.newMessageBuilder(ballerinaToProtoMap);
+            String messageName = type.getTag() == TypeTags.DECIMAL_TAG ? type.getName() : ballerinaToProtoMap;
+            ProtobufMessageBuilder messageBuilder = ProtobufMessage.newMessageBuilder(messageName);
             buildProtobufMessageForBallerinaPrimitiveType(messageBuilder, ballerinaToProtoMap, ATOMIC_FIELD_NAME, 1);
             return messageBuilder.build();
         } else if (type.getTag() == TypeTags.UNION_TAG) {

--- a/native/src/main/java/io/ballerina/stdlib/serdes/protobuf/DataTypeMapper.java
+++ b/native/src/main/java/io/ballerina/stdlib/serdes/protobuf/DataTypeMapper.java
@@ -41,7 +41,7 @@ public class DataTypeMapper {
         javaTypeToProto = new HashMap<>();
         javaTypeToProto.put("Double", "double");
         javaTypeToProto.put("Float", "double");
-        javaTypeToProto.put("DecimalValue", "double");
+        javaTypeToProto.put("DecimalValue", "string");
         javaTypeToProto.put("Integer", "sint64");
         javaTypeToProto.put("Long", "sint64");
         javaTypeToProto.put("Boolean", "bool");
@@ -55,7 +55,7 @@ public class DataTypeMapper {
         ballerinaTypeTagToProto.put(TypeTags.INT_TAG, "sint64");
         ballerinaTypeTagToProto.put(TypeTags.BYTE_TAG, "bytes");
         ballerinaTypeTagToProto.put(TypeTags.FLOAT_TAG, "double");
-        ballerinaTypeTagToProto.put(TypeTags.DECIMAL_TAG, "double");
+        ballerinaTypeTagToProto.put(TypeTags.DECIMAL_TAG, "string");
         ballerinaTypeTagToProto.put(TypeTags.STRING_TAG, "string");
         ballerinaTypeTagToProto.put(TypeTags.BOOLEAN_TAG, "bool");
     }


### PR DESCRIPTION
## Purpose
Add support to decimal type. 

## Examples
```ballerina
type Prices decimal[];

type RecordWithDecimal record {
    decimal 'decimal;
    Prices prices;
};

@test:Config {}
public isolated function testPrimitiveDecimal() returns error? {
    decimal value = 1d / 100000d;

    Proto3Schema ser = check new (decimal);
    byte[] encoded = check ser.serialize(value);

    Proto3Schema des = check new (decimal);
    decimal decoded = check des.deserialize(encoded);
    test:assertEquals(decoded, value);
}

@test:Config {}
public isolated function testRecordWithDecimal() returns error? {
    RecordWithDecimal value = {'decimal: 234.0000000009d, prices: [100.99d, 49.893d, 478.89d]};

    Proto3Schema ser = check new (RecordWithDecimal);
    byte[] encoded = check ser.serialize(value);

    Proto3Schema des = check new (RecordWithDecimal);
    RecordWithDecimal decoded = check des.deserialize(encoded);
    test:assertEquals(decoded, value);
}
```

