### PR TITLE
Extend central-publish workflow to include multiple central environments

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -1,44 +1,83 @@
 name: Publish to the Ballerina central
 
 on:
-    workflow_dispatch:
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        description: Select environment
+        required: true
+        options:
+          - CENTRAL
+          - DEV CENTRAL
+          - STAGE CENTRAL
 
 jobs:
-    publish-release:
-        runs-on: ubuntu-latest
-        if: github.repository_owner == 'ballerina-platform'
-        steps:
-            -   name: Checkout Repository
-                uses: actions/checkout@v2
+  publish-release:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'ballerina-platform'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
 
-            -   name: Set up JDK 11
-                uses: actions/setup-java@v2
-                with:
-                    distribution: 'temurin'
-                    java-version: '11'
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: "temurin"
+          java-version: "11"
 
-            -   name: Build with Gradle
-                env:
-                    packageUser: ${{ github.actor }}
-                    packagePAT: ${{ secrets.GITHUB_TOKEN }}
-                run: ./gradlew build -x check -x test
+      - name: Build with Gradle
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew build -x check -x test
 
-            -   name: Create lib directory if not exists
-                run: mkdir -p ballerina/lib
+      - name: Create lib directory if not exists
+        run: mkdir -p ballerina/lib
 
-            -   name: Run Trivy vulnerability scanner
-                uses: aquasecurity/trivy-action@master
-                with:
-                    scan-type: 'rootfs'
-                    scan-ref: '/github/workspace/ballerina/lib'
-                    format: 'table'
-                    timeout: '10m0s'
-                    exit-code: '1'
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "rootfs"
+          scan-ref: "/github/workspace/ballerina/lib"
+          format: "table"
+          timeout: "10m0s"
+          exit-code: "1"
 
-            -   name: Publish artifact
-                env:
-                    BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
-                    packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
-                    packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
-                    GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
-                run: ./gradlew clean build -PpublishToCentral=true
+      - name: Ballerina Central Push
+        if: ${{ github.event.inputs.environment == 'CENTRAL' }}
+        env:
+          BALLERINA_DEV_CENTRAL: false
+          BALLERINA_STAGE_CENTRAL: false
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+          ./gradlew clean build -PpublishToCentral=true
+
+      - name: Ballerina Central Dev Push
+        if: ${{ github.event.inputs.environment == 'DEV CENTRAL' }}
+        env:
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_STAGE_CENTRAL: false
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+          sed -i 's/version=\(.*\)-SNAPSHOT/version=\1/g' gradle.properties
+          ./gradlew clean build -PpublishToCentral=true
+
+      - name: Ballerina Central Stage Push
+        if: ${{ github.event.inputs.environment == 'STAGE CENTRAL' }}
+        env:
+          BALLERINA_DEV_CENTRAL: false
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+          sed -i 's/version=\(.*\)-SNAPSHOT/version=\1/g' gradle.properties
+          ./gradlew clean build -PpublishToCentral=true

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -21,9 +21,3 @@ path = "./lib/protobuf-java-util-3.21.2.jar"
 groupId = "com.google.protobuf"
 artifactId = "protobuf-java-util"
 version = "3.21.2"
-
-[[platform.java11.dependency]]
-groupId = "io.ballerina.stdlib"
-artifactId = "io-native"
-version = "1.3.0-20220720-110800-3bbc805"
-path = "./lib/io-native-@io.native.version@.jar"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -21,3 +21,9 @@ path = "./lib/protobuf-java-util-3.21.2.jar"
 groupId = "com.google.protobuf"
 artifactId = "protobuf-java-util"
 version = "3.21.2"
+
+[[platform.java11.dependency]]
+groupId = "io.ballerina.stdlib"
+artifactId = "io-native"
+version = "1.3.0-20220720-110800-3bbc805"
+path = "./lib/io-native-@io.native.version@.jar"


### PR DESCRIPTION
## Purpose

Related to: [#3136](https://github.com/ballerina-platform/ballerina-standard-library/issues/3136)

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
